### PR TITLE
Handle managed cluster is deleting

### DIFF
--- a/pkg/agent/manifestwork.go
+++ b/pkg/agent/manifestwork.go
@@ -13,10 +13,6 @@ import (
 	workv1 "open-cluster-management.io/api/work/v1"
 )
 
-const (
-	HOH_AGENT = "hoh-agent"
-)
-
 func CreateHohAgentManifestwork(namespace, boostrapServer, SSLCA string) (*workv1.ManifestWork, error) {
 
 	hoh_version := "latest"
@@ -54,7 +50,7 @@ func CreateHohAgentManifestwork(namespace, boostrapServer, SSLCA string) (*workv
 
 	return &workv1.ManifestWork{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      namespace + "-" + HOH_AGENT,
+			Name:      namespace + "-" + hohAgent,
 			Namespace: namespace,
 			Labels: map[string]string{
 				"hub-of-hubs.open-cluster-management.io/managed-by": "hoh-addon",

--- a/pkg/agent/manifestwork_test.go
+++ b/pkg/agent/manifestwork_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestCreateHohAgentManifestwork(t *testing.T) {
 	agent, _ := CreateHohAgentManifestwork("test", "server", "ca")
-	if agent.GetName() != "test-"+HOH_AGENT {
+	if agent.GetName() != "test-"+hohAgent {
 		t.Fatalf("error")
 	}
 }


### PR DESCRIPTION
if the managed cluster is in deletion, then do not create the hoh agent manifestwork again. leave it to import controller to do clean up.

Signed-off-by: clyang82 <chuyang@redhat.com>