### PR TITLE
fix manifestwork compare logic.

### DIFF
--- a/pkg/agent/manifestwork.go
+++ b/pkg/agent/manifestwork.go
@@ -150,11 +150,11 @@ func CreateHohAgentManifestworkOnHyperHosted(tpl *template.Template, agentConfig
 }
 
 func EnsureManifestWork(existing, desired *workv1.ManifestWork) (bool, error) {
-	if !equality.Semantic.DeepDerivative(existing.Spec.DeleteOption, desired.Spec.DeleteOption) {
+	if !equality.Semantic.DeepDerivative(desired.Spec.DeleteOption, existing.Spec.DeleteOption) {
 		return true, nil
 	}
 
-	if !equality.Semantic.DeepDerivative(existing.Spec.ManifestConfigs, desired.Spec.ManifestConfigs) {
+	if !equality.Semantic.DeepDerivative(desired.Spec.ManifestConfigs, existing.Spec.ManifestConfigs) {
 		return true, nil
 	}
 
@@ -186,7 +186,10 @@ func EnsureManifestWork(existing, desired *workv1.ManifestWork) (bool, error) {
 			}
 		}
 
-		if !equality.Semantic.DeepDerivative(existingObj, desiredObj) {
+		metadata := existingObj.(map[string]interface{})["metadata"].(map[string]interface{})
+		metadata["creationTimestamp"] = nil
+		if !equality.Semantic.DeepDerivative(desiredObj, existingObj) {
+			klog.V(2).Infof("existing manifest object %d is not equal to the desired manifest object", i)
 			return true, nil
 		}
 	}


### PR DESCRIPTION
followup PR for https://github.com/stolostron/hub-of-hubs-addon/pull/12

According the annotation of `equality.Semantic.DeepDerivative`:
https://github.com/kubernetes/apimachinery/blob/97e5df2d0258ac077093867fabf508c1fc31f53b/third_party/forked/golang/reflect/deep_equal.go#L373-L378

the `DeepDerivative` is similar to `DeepEqual` except that unset fields in the first parameter are ignore, it means the order of parameters are important. So we should always use the desired resources as the first parameter.

Signed-off-by: morvencao <lcao@redhat.com>